### PR TITLE
[pcre] fix build pcre undeclared identifier strtoq on arm-android

### DIFF
--- a/ports/pcre/pcre-8.4.5_fix_check_function_exists_for_arm-androi_builds.patch
+++ b/ports/pcre/pcre-8.4.5_fix_check_function_exists_for_arm-androi_builds.patch
@@ -1,0 +1,32 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 2c3a309..cdd480f 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -94,7 +94,7 @@ FIND_PACKAGE( Editline )
+ 
+ INCLUDE(CheckIncludeFile)
+ INCLUDE(CheckIncludeFileCXX)
+-INCLUDE(CheckFunctionExists)
++INCLUDE(CheckSymbolExists)
+ INCLUDE(CheckTypeSize)
+ INCLUDE(GNUInstallDirs) # for CMAKE_INSTALL_LIBDIR
+ 
+@@ -109,12 +109,12 @@ CHECK_INCLUDE_FILE(windows.h    HAVE_WINDOWS_H)
+ CHECK_INCLUDE_FILE_CXX(type_traits.h            HAVE_TYPE_TRAITS_H)
+ CHECK_INCLUDE_FILE_CXX(bits/type_traits.h       HAVE_BITS_TYPE_TRAITS_H)
+ 
+-CHECK_FUNCTION_EXISTS(bcopy     HAVE_BCOPY)
+-CHECK_FUNCTION_EXISTS(memmove   HAVE_MEMMOVE)
+-CHECK_FUNCTION_EXISTS(strerror  HAVE_STRERROR)
+-CHECK_FUNCTION_EXISTS(strtoll   HAVE_STRTOLL)
+-CHECK_FUNCTION_EXISTS(strtoq    HAVE_STRTOQ)
+-CHECK_FUNCTION_EXISTS(_strtoi64 HAVE__STRTOI64)
++CHECK_SYMBOL_EXISTS(bcopy     strings.h     HAVE_BCOPY)
++CHECK_SYMBOL_EXISTS(memmove   strings.h     HAVE_MEMMOVE)
++CHECK_SYMBOL_EXISTS(strerror  strings.h     HAVE_STRERROR)
++CHECK_SYMBOL_EXISTS(strtoll   stdlib.h      HAVE_STRTOLL)
++CHECK_SYMBOL_EXISTS(strtoq    stdlib.h      HAVE_STRTOQ)
++CHECK_SYMBOL_EXISTS(_strtoi64 stdlib.h      HAVE__STRTOI64)
+ 
+ CHECK_TYPE_SIZE("long long"             LONG_LONG)
+ CHECK_TYPE_SIZE("unsigned long long"    UNSIGNED_LONG_LONG)

--- a/ports/pcre/portfile.cmake
+++ b/ports/pcre/portfile.cmake
@@ -7,7 +7,8 @@ set(PATCHES
         pcre-8.45_suppress_cmake_and_compiler_warnings-errors.patch
         # Modified for 8.45 from https://bugs.exim.org/show_bug.cgi?id=2600
         pcre-8.45_fix_postfix_for_debug_Windows_builds.patch
-        export-cmake-targets.patch)
+        export-cmake-targets.patch
+        pcre-8.4.5_fix_check_function_exists_for_arm-androi_builds.patch)
 
 vcpkg_from_sourceforge(
     OUT_SOURCE_PATH SOURCE_PATH

--- a/ports/pcre/vcpkg.json
+++ b/ports/pcre/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "pcre",
   "version": "8.45",
-  "port-version": 2,
+  "port-version": 3,
   "description": "Perl Compatible Regular Expressions",
   "homepage": "https://www.pcre.org/",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5350,7 +5350,7 @@
     },
     "pcre": {
       "baseline": "8.45",
-      "port-version": 2
+      "port-version": 3
     },
     "pcre2": {
       "baseline": "10.40",

--- a/versions/p-/pcre.json
+++ b/versions/p-/pcre.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "e2463ba809c82d224964004bebf56c8dc5169ed7",
+      "version": "8.45",
+      "port-version": 3
+    },
+    {
       "git-tree": "693b4da6141be8041f8db0caa1b60ce246b47dcb",
       "version": "8.45",
       "port-version": 2


### PR DESCRIPTION
* replace CHECK_FUNCTION_EXISTS by CHECK_SYMBOL_EXISTS

**Describe the pull request**

- #### What does your PR fix?
  fix build pcre on arm-android error in CMakeLists.txt

- #### Which triplets are supported/not supported? Have you updated the [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt)?
  <linux, windows, macos>, <Yes/No>

- #### Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
  `Yes`

- #### If you have added/updated a port: Have you run `./vcpkg x-add-version --all` and committed the result?
  <Yes>

**If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/**
